### PR TITLE
Add Dopastep to Individual Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,7 @@ Online and mobile apps made by indie devs that bring enjoyment
 - [Token Board](https://www.thetokenboard.com) - A free online and mobile-friendly token board with different shapes & colors.
 - [Visual Countdown Timer](https://apps.apple.com/us/app/visual-countdown-timer/id541364004) - iOS app developed by a parent that uses fun pictures to perform a task quickly.
 - [Accessible Chef](https://accessiblechef.com) - A collection of free visual recipes that makes use of task analysis.
+- [Dopastep](https://dopastep.com) - Web app for body doubling: break a task into steps, then join a live focus room and work alongside other people in synced focus and break cycles.
 
 ## 👓 AR / VR
 


### PR DESCRIPTION
Adds Dopastep to Individual Apps.

**Disclosure: I built this, so please treat it as a suggestion rather than a neutral recommendation.** Completely fine to close this if it isn't a fit.

It's an online app made by a solo indie dev, which matches this section's description. Body doubling — working alongside someone else so that starting a task gets easier — is a common accommodation for task-initiation difficulty in autistic and ADHD adults. Dopastep does it without a camera, chat, booking or partner matching: you open a room, see how many people are in it and which phase the shared timer is in, and work. You don't need an account to look around.

Happy to reword the entry or move it to Collaboration if you think that fits better.
