### PR TITLE
Add Masked But Aware Crisis Mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,7 @@ Online and mobile apps made by indie devs that bring enjoyment
 - [Token Board](https://www.thetokenboard.com) - A free online and mobile-friendly token board with different shapes & colors.
 - [Visual Countdown Timer](https://apps.apple.com/us/app/visual-countdown-timer/id541364004) - iOS app developed by a parent that uses fun pictures to perform a task quickly.
 - [Accessible Chef](https://accessiblechef.com) - A collection of free visual recipes that makes use of task analysis.
+- [Masked But Aware Crisis Mode](https://www.maskedbutaware.nl/en/tools/crisis-mode) - Free, low-stimulation browser tool for reducing sensory input and showing a prepared phrase when speaking becomes difficult. No account required.
 
 ## 👓 AR / VR
 


### PR DESCRIPTION
Adds Masked But Aware Crisis Mode to Individual Apps. It is a free, mobile-friendly browser tool that first helps reduce sensory input and also offers prepared phrases for moments when speaking is difficult. It requires no account and clearly distinguishes self-help from emergency support.\n\nDisclosure: I maintain the submitted resource. The list entry links directly to the live tool.